### PR TITLE
Expand date headers on search in markdown collection page

### DIFF
--- a/dataHandlers.js
+++ b/dataHandlers.js
@@ -149,7 +149,7 @@ function renderMarkdownData(markdownData, container, openUrls, query, filters) {
 
         const dateContent = document.createElement('div');
         dateContent.className = 'date-content';
-        dateContent.style.display = date === getTodayDate() ? 'block' : 'none'; // Only current date expanded by default
+        dateContent.style.display = date === getTodayDate() || query ? 'block' : 'none'; // Ensure date headers are expanded when search results are displayed
 
         dateHeader.addEventListener('click', () => {
           dateContent.style.display = dateContent.style.display === 'none' ? 'block' : 'none';

--- a/markdown.js
+++ b/markdown.js
@@ -4,7 +4,7 @@
  * Markdown Collector is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * (at any time) any later version.
  *
  * Markdown Collector is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Modify the `loadMarkdownData` function in `dataHandlers.js` to ensure date headers are expanded when search results are displayed.

* Update the `dateContent` display logic to expand date headers when a search query is present.

