### PR TITLE
Update settings page with LLM refinement options

### DIFF
--- a/scripts/components/settings.js
+++ b/scripts/components/settings.js
@@ -24,7 +24,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const modelSelect = document.getElementById('model-select');
   const customModel = document.getElementById('custom-model');
   const baseUrlInput = document.getElementById('base-url');
+  const resetBaseUrlButton = document.getElementById('reset-base-url');
   const subSettingsContainer = document.querySelector('.sub-settings-container');
+
+  const DEFAULT_BASE_URL = 'https://api.openai.com/v1/chat/completions';
 
   // Initialize settings
   chrome.storage.local.get(['enableCleanup', 'enableLLM', 'apiKey', 'model', 'baseUrl'], (result) => {
@@ -37,7 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       modelSelect.value = result.model || 'gpt-4o-mini';
     }
-    baseUrlInput.value = result.baseUrl || 'https://api.openai.com/v1/chat/completions';
+    baseUrlInput.value = result.baseUrl || DEFAULT_BASE_URL;
     updateToggleVisually(cleanupToggle);
     updateToggleVisually(llmToggle);
     subSettingsContainer.style.display = result.enableLLM ? 'block' : 'none';
@@ -91,6 +94,13 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('Base URL saved');
     });
   }, 500));
+
+  resetBaseUrlButton.addEventListener('click', () => {
+    baseUrlInput.value = DEFAULT_BASE_URL;
+    chrome.storage.local.set({ baseUrl: DEFAULT_BASE_URL }, () => {
+      console.log('Base URL reset to default');
+    });
+  });
 
   function updateModelInputVisibility() {
     if (modelSelect.value === 'custom') {

--- a/settings.html
+++ b/settings.html
@@ -352,7 +352,7 @@
       <div class="setting" id="base-url-setting">
         <label for="base-url">API Base URL</label>
         <div style="display: flex; align-items: center;">
-          <input type="text" id="base-url" placeholder="Enter your API base URL">
+          <input type="text" id="base-url" placeholder="Enter API base URL">
           <button id="reset-base-url">Reset</button>
         </div>
       </div>

--- a/settings.html
+++ b/settings.html
@@ -137,6 +137,13 @@
       position: relative;
     }
 
+    #model-info {
+      width: 100px;
+      border-radius: 10px;
+      padding-left: 0;
+      padding-right: 0;
+    }
+
     .info-popup {
       display: none;
       position: absolute;
@@ -299,12 +306,6 @@
             <div class="note">
               <strong>Note:</strong> It's recommended to enable "Keep main content only" to make content cleaner before feeding it to the AI. This helps because LLMs have limited context lengths (the default model, gpt-4o-mini, has a 128,000 token context window, which should fit most cleaned web page contents).
             </div>
-            <div class="note">
-              <strong>API Key:</strong> You can find your OpenAI API key <a href="https://platform.openai.com/api-keys" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">here</a> or follow the instructions <a href="https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">here</a>.
-            </div>
-            <div class="note">
-              <strong>Local LLMs:</strong> Local LLMs can be used too, e.g., with <a href="https://lmstudio.ai/" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">LM Studio</a> or <a href="https://ollama.com/" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">Ollama</a>. The user just needs to pass the server URL and model name.
-            </div>
           </span>
         </span>
       </label>
@@ -316,7 +317,13 @@
 
     <div class="sub-settings-container" style="display: none;">
       <div class="setting" id="api-key-setting">
-        <label for="api-key">OpenAI API Key</label>
+        <label for="api-key">OpenAI API Key
+          <span class="info-icon">?
+            <span class="info-popup">
+              You can find your OpenAI API key <a href="https://platform.openai.com/api-keys" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">here</a> or follow the instructions <a href="https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">here</a>.
+            </span>
+          </span>
+        </label>
         <div style="display: flex; align-items: center;">
           <div style="flex-grow: 1; display: flex; align-items: center;">
             <input type="password" id="api-key" placeholder="Enter your OpenAI API key" style="flex-grow: 1;">
@@ -325,7 +332,13 @@
       </div>
 
       <div class="setting" id="model-setting">
-        <label for="model-select">AI Model</label>
+        <label for="model-select">AI Model
+          <span class="info-icon" id="model-info">Local Models
+            <span class="info-popup">
+              Local Large Language Models can be used too, e.g., with <a href="https://lmstudio.ai/" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">LM Studio</a> or <a href="https://ollama.com/" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">Ollama</a>. Server endpoints need to support the OpenAI function calling feature. Simply pass the server URL and model name.
+            </span>
+          </span>
+        </label>
         <div style="display: flex; align-items: center;">
           <input type="text" id="custom-model" placeholder="Enter custom model name">
           <select id="model-select">
@@ -339,7 +352,8 @@
       <div class="setting" id="base-url-setting">
         <label for="base-url">API Base URL</label>
         <div style="display: flex; align-items: center;">
-          <input type="text" id="base-url" placeholder="Enter API base URL">
+          <input type="text" id="base-url" placeholder="Enter your API base URL">
+          <button id="reset-base-url">Reset</button>
         </div>
       </div>
     </div>

--- a/settings.html
+++ b/settings.html
@@ -299,6 +299,12 @@
             <div class="note">
               <strong>Note:</strong> It's recommended to enable "Keep main content only" to make content cleaner before feeding it to the AI. This helps because LLMs have limited context lengths (the default model, gpt-4o-mini, has a 128,000 token context window, which should fit most cleaned web page contents).
             </div>
+            <div class="note">
+              <strong>API Key:</strong> You can find your OpenAI API key <a href="https://platform.openai.com/api-keys" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">here</a> or follow the instructions <a href="https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">here</a>.
+            </div>
+            <div class="note">
+              <strong>Local LLMs:</strong> Local LLMs can be used too, e.g., with <a href="https://lmstudio.ai/" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">LM Studio</a> or <a href="https://ollama.com/" target="_blank" style="color: rgb(79, 138, 255); text-decoration: none;">Ollama</a>. The user just needs to pass the server URL and model name.
+            </div>
           </span>
         </span>
       </label>


### PR DESCRIPTION
Update the settings page for the LLM refinement options infobox to include additional guidance and information.

* Add a link to `https://platform.openai.com/api-keys` for finding the OpenAI API key.
* Add a link to `https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key` for instructions on finding the OpenAI API key.
* Add a note stating that local LLMs can be used, e.g., with `https://lmstudio.ai/` or `https://ollama.com/`, and that the user just needs to pass the server URL and model name.

